### PR TITLE
Handle SENDER_ID_MISMATCH with a dedicated exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,11 @@ Please update your remote URL if you have forked or cloned the repository.
 
 ## Unreleased
 
-* Messaging: FCM `403 PERMISSION_DENIED` responses with the error code `SENDER_ID_MISMATCH` are now
+## Messaging
+
+* FCM `403 PERMISSION_DENIED` responses with the error code `SENDER_ID_MISMATCH` are now
   converted to a dedicated `Kreait\Firebase\Exception\Messaging\SenderIdMismatch` exception instead of
-  the more generic `AuthenticationError`. A sender ID mismatch is a permanent, per-token failure (the
-  token belongs to a different Firebase project) and not a problem with the project's credentials, so
-  it can now be handled like an unregistered token. Other `401`/`403` responses are still converted
-  to `AuthenticationError`.
+  the more generic `AuthenticationError`.
 
 ## 8.4.0 - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Please update your remote URL if you have forked or cloned the repository.
 
 ## Unreleased
 
+* Messaging: FCM `403 PERMISSION_DENIED` responses with the error code `SENDER_ID_MISMATCH` are now
+  converted to a dedicated `Kreait\Firebase\Exception\Messaging\SenderIdMismatch` exception instead of
+  the more generic `AuthenticationError`. A sender ID mismatch is a permanent, per-token failure (the
+  token belongs to a different Firebase project) and not a problem with the project's credentials, so
+  it can now be handled like an unregistered token. Other `401`/`403` responses are still converted
+  to `AuthenticationError`.
+
 ## 8.4.0 - 2026-08-05
 
 * Added support for `guzzlehttp/guzzle:^8.0`, `guzzlehttp/psr7:^3.0` and `guzzlehttp/promises:^3.0`.

--- a/docs/cloud-messaging.rst
+++ b/docs/cloud-messaging.rst
@@ -779,6 +779,27 @@ syntactically correct, this usually has one of the following reasons:
         echo $e->token();
     }
 
+Mismatched registration tokens
+------------------------------
+
+If a registration token is registered to a *different* Firebase project than the project
+you are using to send the message, the FCM API rejects the message with a
+``SENDER_ID_MISMATCH`` error. Like an unknown token, this is a permanent failure for
+this token - it will never be reachable from your project, so it should be removed
+from your list of message targets. In contrast to other authentication errors, it does
+not indicate a problem with your project's credentials.
+
+.. code-block:: php
+
+    use Kreait\Firebase\Exception\Messaging\SenderIdMismatch;
+
+    try {
+        $messaging->send($message);
+    } catch (SenderIdMismatch $e) {
+        echo $e->getMessage();
+        print_r($e->errors());
+    }
+
 Quota exceeded
 --------------
 
@@ -836,6 +857,8 @@ Error handling example
         $messaging->send($message);
     } catch (MessagingErrors\NotFound $e) {
         echo 'The target device could not be found.';
+    } catch (MessagingErrors\SenderIdMismatch $e) {
+        echo 'The target device belongs to a different Firebase project.';
     } catch (MessagingErrors\InvalidMessage $e) {
         echo 'The given message is malformatted.';
     } catch (MessagingErrors\ServerUnavailable $e) {

--- a/src/Exception/Messaging/SenderIdMismatch.php
+++ b/src/Exception/Messaging/SenderIdMismatch.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Exception\Messaging;
+
+use Kreait\Firebase\Exception\HasErrors;
+use Kreait\Firebase\Exception\MessagingException;
+use Kreait\Firebase\Exception\RuntimeException;
+
+/**
+ * The registration token is registered to a different Firebase project than the
+ * project the message is sent from. This is a permanent, per-token failure: the
+ * token should be treated like an unregistered token and removed from the list
+ * of message targets.
+ */
+final class SenderIdMismatch extends RuntimeException implements MessagingException
+{
+    use HasErrors;
+
+    /**
+     * @internal
+     *
+     * @param array<mixed> $errors
+     */
+    public function withErrors(array $errors): self
+    {
+        $new = new self(message: $this->getMessage(), previous: $this->getPrevious());
+        $new->errors = $errors;
+
+        return $new;
+    }
+}

--- a/src/Exception/MessagingApiExceptionConverter.php
+++ b/src/Exception/MessagingApiExceptionConverter.php
@@ -15,6 +15,7 @@ use Kreait\Firebase\Exception\Messaging\InvalidMessage;
 use Kreait\Firebase\Exception\Messaging\MessagingError;
 use Kreait\Firebase\Exception\Messaging\NotFound;
 use Kreait\Firebase\Exception\Messaging\QuotaExceeded;
+use Kreait\Firebase\Exception\Messaging\SenderIdMismatch;
 use Kreait\Firebase\Exception\Messaging\ServerError;
 use Kreait\Firebase\Exception\Messaging\ServerUnavailable;
 use Kreait\Firebase\Http\ErrorResponseParser;
@@ -23,6 +24,7 @@ use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
+use function is_array;
 use function is_numeric;
 
 /**
@@ -74,8 +76,14 @@ final readonly class MessagingApiExceptionConverter
                 break;
 
             case StatusCode::STATUS_UNAUTHORIZED:
-            case StatusCode::STATUS_FORBIDDEN:
                 $convertedError = new AuthenticationError($message, previous: $previous);
+
+                break;
+
+            case StatusCode::STATUS_FORBIDDEN:
+                $convertedError = $this->isSenderIdMismatch($errors, $message)
+                    ? new SenderIdMismatch($message, previous: $previous)
+                    : new AuthenticationError($message, previous: $previous);
 
                 break;
 
@@ -146,6 +154,26 @@ final readonly class MessagingApiExceptionConverter
         }
 
         return new MessagingError(message: $e->getMessage(), previous: $e);
+    }
+
+    /**
+     * @see https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode
+     *
+     * @param array<mixed> $errors
+     */
+    private function isSenderIdMismatch(array $errors, string $message): bool
+    {
+        $details = $errors['error']['details'] ?? [];
+
+        if (is_array($details)) {
+            foreach ($details as $detail) {
+                if (is_array($detail) && ($detail['errorCode'] ?? null) === 'SENDER_ID_MISMATCH') {
+                    return true;
+                }
+            }
+        }
+
+        return mb_strtolower($message) === 'senderid mismatch';
     }
 
     private function getRetryAfter(ResponseInterface $response): ?DateTimeImmutable

--- a/src/Messaging/SendReport.php
+++ b/src/Messaging/SendReport.php
@@ -6,6 +6,7 @@ namespace Kreait\Firebase\Messaging;
 
 use Kreait\Firebase\Exception\Messaging\InvalidMessage;
 use Kreait\Firebase\Exception\Messaging\NotFound;
+use Kreait\Firebase\Exception\Messaging\SenderIdMismatch;
 use Kreait\Firebase\Exception\MessagingException;
 
 use function preg_match;
@@ -75,7 +76,8 @@ final class SendReport
 
     public function messageWasSentToUnknownToken(): bool
     {
-        return $this->error instanceof NotFound;
+        return $this->error instanceof NotFound
+            || $this->error instanceof SenderIdMismatch;
     }
 
     /**

--- a/tests/Unit/Exception/MessagingApiExceptionConverterTest.php
+++ b/tests/Unit/Exception/MessagingApiExceptionConverterTest.php
@@ -18,6 +18,7 @@ use Kreait\Firebase\Exception\Messaging\InvalidMessage;
 use Kreait\Firebase\Exception\Messaging\MessagingError;
 use Kreait\Firebase\Exception\Messaging\NotFound;
 use Kreait\Firebase\Exception\Messaging\QuotaExceeded;
+use Kreait\Firebase\Exception\Messaging\SenderIdMismatch;
 use Kreait\Firebase\Exception\Messaging\ServerError;
 use Kreait\Firebase\Exception\Messaging\ServerUnavailable;
 use Kreait\Firebase\Exception\MessagingApiExceptionConverter;
@@ -105,6 +106,56 @@ final class MessagingApiExceptionConverterTest extends TestCase
                 ],
             ])),
         );
+    }
+
+    public function testItConvertsASenderIdMismatchResponseIdentifiedByItsErrorCode(): void
+    {
+        // Error shape as returned by the FCM HTTP v1 API
+        // https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode
+        $response = new Response(403, [], Json::encode([
+            'error' => [
+                'code' => 403,
+                'message' => 'SenderId mismatch',
+                'status' => 'PERMISSION_DENIED',
+                'details' => [
+                    [
+                        '@type' => 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+                        'errorCode' => 'SENDER_ID_MISMATCH',
+                    ],
+                ],
+            ],
+        ]));
+
+        $converted = $this->converter->convertResponse($response);
+
+        $this->assertInstanceOf(SenderIdMismatch::class, $converted);
+        $this->assertNotEmpty($converted->errors());
+    }
+
+    public function testItConvertsASenderIdMismatchResponseIdentifiedByItsMessage(): void
+    {
+        $response = new Response(403, [], Json::encode([
+            'error' => [
+                'code' => 403,
+                'message' => 'SenderId mismatch',
+                'status' => 'PERMISSION_DENIED',
+            ],
+        ]));
+
+        $this->assertInstanceOf(SenderIdMismatch::class, $this->converter->convertResponse($response));
+    }
+
+    public function testItConvertsOtherForbiddenResponsesToAuthenticationErrors(): void
+    {
+        $response = new Response(403, [], Json::encode([
+            'error' => [
+                'code' => 403,
+                'message' => 'The caller does not have permission',
+                'status' => 'PERMISSION_DENIED',
+            ],
+        ]));
+
+        $this->assertInstanceOf(AuthenticationError::class, $this->converter->convertResponse($response));
     }
 
     public function testItKnowsWhenToRetryAfterWithSeconds(): void

--- a/tests/Unit/Messaging/MulticastSendReportTest.php
+++ b/tests/Unit/Messaging/MulticastSendReportTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kreait\Firebase\Tests\Unit\Messaging;
+
+use Iterator;
+use Kreait\Firebase\Exception\Messaging\NotFound;
+use Kreait\Firebase\Exception\Messaging\SenderIdMismatch;
+use Kreait\Firebase\Exception\MessagingException;
+use Kreait\Firebase\Messaging\MessageTarget;
+use Kreait\Firebase\Messaging\MulticastSendReport;
+use Kreait\Firebase\Messaging\SendReport;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class MulticastSendReportTest extends TestCase
+{
+    #[DataProvider('unknownTokenErrors')]
+    public function testItReturnsUnknownTokens(MessagingException $error): void
+    {
+        $target = MessageTarget::with(MessageTarget::TOKEN, 'token-from-another-project');
+        $sendReport = SendReport::failure($target, $error);
+        $report = MulticastSendReport::withItems([$sendReport]);
+
+        $this->assertSame(['token-from-another-project'], $report->unknownTokens());
+    }
+
+    /**
+     * @return Iterator<string, array{MessagingException}>
+     */
+    public static function unknownTokenErrors(): Iterator
+    {
+        yield 'not found' => [new NotFound('Not found')];
+        yield 'sender ID mismatch' => [new SenderIdMismatch('SenderId mismatch')];
+    }
+}


### PR DESCRIPTION
Resolves #1123

### What this does

FCM rejects messages sent to a registration token that belongs to a *different* Firebase project with `403 PERMISSION_DENIED` and the error code `SENDER_ID_MISMATCH`. Until now, `MessagingApiExceptionConverter::convertResponse()` converted this response to the same `AuthenticationError` as `401` responses, although the two conditions require opposite handling: a 401 is a service-level credential problem (alert an operator), while a sender ID mismatch is a permanent, per-token failure that should be handled like an unregistered token (prune the token, no alert).

With this change, 403 responses carrying the `SENDER_ID_MISMATCH` error code in the error details (with the `"SenderId mismatch"` message as a fallback marker) are converted to a new, dedicated `Kreait\Firebase\Exception\Messaging\SenderIdMismatch` exception:

```php
try {
    $messaging->send($message);
} catch (SenderIdMismatch $e) {
    // permanent per-token failure: remove the token from the target list
} catch (AuthenticationError $e) {
    // actual credential problem: alert an operator
}
```

This mirrors the official Admin SDKs (`messaging/sender-id-mismatch` in Node.js, `MessagingErrorCode.SENDER_ID_MISMATCH` in Java, `IsSenderIDMismatch()` in Go) and follows the existing precedent of `NotFound` for `UNREGISTERED` tokens.

### Backward compatibility

All other 401/403 responses are still converted to `AuthenticationError`; only the specific `SENDER_ID_MISMATCH` case gets the new type. The new exception implements `MessagingException` like every other messaging exception, so generic `catch (MessagingException $e)` handlers are unaffected.

### Included

- `SenderIdMismatch` exception (same shape as the existing `AuthenticationError`/`NotFound`)
- Detection in `MessagingApiExceptionConverter` (error details first, message as fallback)
- 3 unit tests (detection by error code, by message, and a guard that other 403s remain `AuthenticationError`)
- Docs section "Mismatched registration tokens" in `docs/cloud-messaging.rst` + error-handling example update
- CHANGELOG entry under Unreleased

### Checks

- `test:unit`: 361 tests OK
- `analyze` (PHPStan): no errors
- `lint` (PHP-CS-Fixer + Rector): clean
